### PR TITLE
Bump log4j.version from 2.1 to 2.13.3 in /bin

### DIFF
--- a/bin/pom.xml
+++ b/bin/pom.xml
@@ -16,7 +16,7 @@
 		<maven.compiler.source>8</maven.compiler.source>
 		<maven.compiler.target>8</maven.compiler.target>
 		<slf4j.version>1.7.12</slf4j.version>
-		<log4j.version>2.1</log4j.version>
+		<log4j.version>2.13.3</log4j.version>
 		<CI.BuildNumber></CI.BuildNumber>
 		<CI.PrefixBuild></CI.PrefixBuild>
 	</properties>


### PR DESCRIPTION
Bumps `log4j.version` from 2.1 to 2.13.3.

Updates `log4j-api` from 2.1 to 2.13.3

Updates `log4j-core` from 2.1 to 2.13.3

Signed-off-by: dependabot[bot] <support@github.com>