### PR TITLE
Bump log4j-api from 2.1 to 2.16.0 in /bin

### DIFF
--- a/bin/pom.xml
+++ b/bin/pom.xml
@@ -16,7 +16,7 @@
 		<maven.compiler.source>8</maven.compiler.source>
 		<maven.compiler.target>8</maven.compiler.target>
 		<slf4j.version>1.7.12</slf4j.version>
-		<log4j.version>2.1</log4j.version>
+		<log4j.version>2.16.0</log4j.version>
 		<CI.BuildNumber></CI.BuildNumber>
 		<CI.PrefixBuild></CI.PrefixBuild>
 	</properties>


### PR DESCRIPTION
Bumps log4j-api from 2.1 to 2.16.0.

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-api
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>